### PR TITLE
Trusted auth typos

### DIFF
--- a/modules/ROOT/pages/trusted-auth-sdk.adoc
+++ b/modules/ROOT/pages/trusted-auth-sdk.adoc
@@ -92,7 +92,7 @@ Cookieless authentication is also useful for scenarios where the embedding appli
 == Code examples
 The only difference between cookie-based trusted authentication and cookieless authentication in the `init()` function is the value used for the `authType` property. 
 
-Cookieless auth does not require the `username` property, as the `username` value is encoded within the token.
+Cookieless authentication does not require the `username` property, as the `username` value is encoded within the token.
 
 The following example shows a custom callback function with a custom request using link:https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch[Fetch, window=_blank], which returns a Promise. This example shows passing a JWT into the header of the POST request as the method for passing auth details to the *token request service*. See other examples below for simpler request implementations.
 

--- a/modules/ROOT/pages/trusted-auth-sdk.adoc
+++ b/modules/ROOT/pages/trusted-auth-sdk.adoc
@@ -58,7 +58,7 @@ init({
     authType: AuthType.TrustedAuthToken,
     username: "<username>",
     getAuthToken: () => {
-        let tsToken = '{long-lived-token};
+        let tsToken = '{long-lived-token}';
         return tsToken;
  });
 ----
@@ -92,7 +92,7 @@ Cookieless authentication is also useful for scenarios where the embedding appli
 == Code examples
 The only difference between cookie-based trusted authentication and cookieless authentication in the `init()` function is the value used for the `authType` property. 
 
-Cookieeless auth does not require the `username` property, as the `username` value is encoded within the token.
+Cookieless auth does not require the `username` property, as the `username` value is encoded within the token.
 
 The following example shows a custom callback function with a custom request using link:https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch[Fetch, window=_blank], which returns a Promise. This example shows passing a JWT into the header of the POST request as the method for passing auth details to the *token request service*. See other examples below for simpler request implementations.
 

--- a/modules/ROOT/pages/trusted-authentication.adoc
+++ b/modules/ROOT/pages/trusted-authentication.adoc
@@ -35,37 +35,17 @@ If you are embedding ThoughtSpot content in an app that is not in the same domai
 See the xref:trusted-auth-sdk.adoc[Visual Embed SDK documentation] for the exact details of implementing either form of trusted authentication.
 
 == How to turn off trusted authentication
-
-To disable trusted authentication, follow these steps:
-
-. Log in to ThoughtSpot.
-. If the per-Org secret key feature is enabled and Orgs are configured on your instance, switch to the Org for which you want to disable trusted authentication.
-. Go to *Develop* > *Customizations* > *Security settings*.
-. Click *Edit* and turn off the *Trusted authentication* toggle.
-+
-A pop-up window appears and prompts you to confirm the disable action.
-
-. Click *Disable*.
-
-+
-When you disable trusted authentication, the validity of your existing secret key expires, and your app may become inoperable.
-
-
-== Trusted authentication code samples
-
-The following GitHub repositories include code samples for trusted authentication implementation:
-
-* Sample code for the app backend to include an authentication server for ThoughtSpot:
-** link:https://github.com/thoughtspot/node-token-auth-server-example[TypeScript, window=_blank]
-** link:https://github.com/thoughtspot/ts_everywhere_resources/tree/master/examples/token_auth[Python (Flask Service), window=_blank]
-* Sample code of an application frontend authenticating via trusted authentication.
-** link:https://github.com/thoughtspot/big-react-demo[React code samples, window=_blank]
-
-To a new secret key and generate authentication tokens, you must enable Trusted authentication.
-
+xref:trusted-auth-secret-key.adoc#disable-trusted-authentication[Disabling trusted authentication] also invalidates the previous `secret_key`.
 
 == Troubleshoot trusted authentication
 Please see the xref:trusted-auth-troubleshoot.adoc[troubleshooting steps] if you encounter issues with the browse-side aspects of the trusted authentication implementation.
+
+== Trusted authentication code samples
+Code examples for implementations of a `token request service` xref:trusted-auth-token-request-service.adoc#code-examples[are available here].
+
+Examples of front-end JavaScript for trusted auth using the Visual Embed SDK are xref:trusted-auth-sdk.adoc#code-examples[documented here].
+
+The sample code of an application frontend authenticating via trusted authentication is available using link:https://github.com/thoughtspot/big-react-demo[the React components, window=_blank].
 
 [#rest-api]
 == REST API back-end use cases

--- a/modules/ROOT/pages/trusted-authentication.adoc
+++ b/modules/ROOT/pages/trusted-authentication.adoc
@@ -35,7 +35,7 @@ If you are embedding ThoughtSpot content in an app that is not in the same domai
 See the xref:trusted-auth-sdk.adoc[Visual Embed SDK documentation] for the exact details of implementing either form of trusted authentication.
 
 == How to turn off trusted authentication
-xref:trusted-auth-secret-key.adoc#disable-trusted-authentication[Disable trusted authentication] also invalidates the previous `secret_key`.
+xref:trusted-auth-secret-key.adoc#disable-trusted-authentication[Disabling trusted authentication] also invalidates the previous `secret_key`.
 
 == Troubleshoot trusted authentication
 Please see the xref:trusted-auth-troubleshoot.adoc[troubleshooting steps] if you encounter issues with the browse-side aspects of the trusted authentication implementation.

--- a/modules/ROOT/pages/trusted-authentication.adoc
+++ b/modules/ROOT/pages/trusted-authentication.adoc
@@ -35,7 +35,7 @@ If you are embedding ThoughtSpot content in an app that is not in the same domai
 See the xref:trusted-auth-sdk.adoc[Visual Embed SDK documentation] for the exact details of implementing either form of trusted authentication.
 
 == How to turn off trusted authentication
-xref:trusted-auth-secret-key.adoc#disable-trusted-authentication[Disabling trusted authentication] also invalidates the previous `secret_key`.
+xref:trusted-auth-secret-key.adoc#disable-trusted-authentication[Disable trusted authentication] also invalidates the previous `secret_key`.
 
 == Troubleshoot trusted authentication
 Please see the xref:trusted-auth-troubleshoot.adoc[troubleshooting steps] if you encounter issues with the browse-side aspects of the trusted authentication implementation.
@@ -43,7 +43,7 @@ Please see the xref:trusted-auth-troubleshoot.adoc[troubleshooting steps] if you
 == Trusted authentication code samples
 Code examples for implementations of a `token request service` xref:trusted-auth-token-request-service.adoc#code-examples[are available here].
 
-Examples of front-end JavaScript for trusted auth using the Visual Embed SDK are xref:trusted-auth-sdk.adoc#code-examples[documented here].
+Examples of front-end JavaScript for trusted authentication using the Visual Embed SDK are xref:trusted-auth-sdk.adoc#code-examples[documented here].
 
 The sample code of an application frontend authenticating via trusted authentication is available using link:https://github.com/thoughtspot/big-react-demo[the React components, window=_blank].
 


### PR DESCRIPTION
Fixed a few small typos that were noticeable in the final published version, and switched a few sections of the overview to provide links to the sub-pages where those sections have been moved to