### PR TITLE
Update trusted-auth-sdk.adoc

### DIFF
--- a/modules/ROOT/pages/trusted-auth-sdk.adoc
+++ b/modules/ROOT/pages/trusted-auth-sdk.adoc
@@ -51,7 +51,7 @@ init({
 });
 ----
 
-You can even use the callback function to reference a hard-coded login token, in a testing or other appropriate situation: 
+You can even use the callback function to reference a hard-coded login token, in a testing or other appropriate situation. Remember, it must return a Promise that resolves with the token: 
 
 [source,JavaScript]
 ----
@@ -61,7 +61,7 @@ init({
 	username: "<username>",
 	getAuthToken: () => {
 		let tsToken = '{long-lived-token}';
-		return tsToken;
+		return Promise.resolve(tsToken);
 	}
 });
 ----


### PR DESCRIPTION
The code on the page for a static token return was incorrect and we've hit two customers encountering errors following wrong method. I updated with code that works from one of our test examples we use all the time.