### PR TITLE
Tokenized fetch update 1

### DIFF
--- a/modules/ROOT/pages/rest-apiv2-js.adoc
+++ b/modules/ROOT/pages/rest-apiv2-js.adoc
@@ -8,7 +8,7 @@
 
 REST API v2.0 uses JSON for the request and the response format, so it is easy to implement any v2.0 call in JavaScript. 
 
-Every REST API v2.0 endpoint uses either an HTTP GET or POST request, with or without a JSON request, so this simple async wrapper function can be used generically to build out any specific endpoint request. Before making an API request to a REST API v2.0 endpoint, make sure you xref:authentication.adoc[obtain a bearer token or set session cookies].
+Every REST API v2.0 endpoint uses either an HTTP GET or POST request, with or without a JSON request, so this simple async wrapper function can be used generically to build out any specific endpoint request. Before making an API request to a REST API v2.0 endpoint, xref:authentication.adoc[obtain a bearer token or set session cookies].
 
 The Visual Embed SDK includes a link:https://developers.thoughtspot.com/docs/Function_tokenizedFetch[tokenizedFetch function, target=_blank] which will automatically add the bearer token that the SDK has retrieved already. Add `tokenizedFetch` to the list of imports from the Visual Embed SDK, and then the following code will work for any authorization method:
 
@@ -62,7 +62,7 @@ async function restApiCallV2(endpoint, httpVerb, apiRequestObject){
                 return response.json(); // Returns the JSON of the response 
             }
             else if (response.status === 204){
-                return true;  // 204 is success without any body
+                return true;  // 204 is success without a response body
             }
         }
     }).catch(error =>

--- a/modules/ROOT/pages/rest-apiv2-js.adoc
+++ b/modules/ROOT/pages/rest-apiv2-js.adoc
@@ -10,8 +10,12 @@ REST API v2.0 uses JSON for the request and the response format, so it is easy t
 
 Every REST API v2.0 endpoint uses either an HTTP GET or POST request, with or without a JSON request, so this simple async wrapper function can be used generically to build out any specific endpoint request. Before making an API request to a REST API v2.0 endpoint, make sure you xref:authentication.adoc[obtain a bearer token or set session cookies].
 
+The Visual Embed SDK includes a link:https://developers.thoughtspot.com/docs/Function_tokenizedFetch[tokenizedFetch function, target=_blank] which will automatically add the bearer token that the SDK has retrieved already. Add `tokenizedFetch` to the list of imports from the Visual Embed SDK, and then the following code will work for any authorization method:
+
 [source,javascript]
 ----
+/* Make sure to add tokenizedFetch to your imports from the Visual Embed SDK */
+
 /*
 * Generic function to make a call to the V2.0 REST API 
 * 
@@ -35,8 +39,8 @@ async function restApiCallV2(endpoint, httpVerb, apiRequestObject){
     if (apiRequestObj !== null){
         fetchArgs['body'] = JSON.stringify(apiRequestObj);
     }
-    // With the async modifier on the function, you add return await to the fetch() call here
-    return await fetch(
+    // With the async modifier on the function, you add return await to the fetch() or tokenizedFetch() call here
+    return await tokenizedFetch(
         apiFullEndpoint,
         fetchArgs
     ).then(response =>

--- a/modules/ROOT/pages/trusted-auth-sdk.adoc
+++ b/modules/ROOT/pages/trusted-auth-sdk.adoc
@@ -85,9 +85,9 @@ When used as a bearer token, the lifespan of the token is established when it is
 The `init()` function can automatically request a new token when it detects either the session or the token has expired if the `autoLogin: true` option is set. You may also set `disableLoginRedirect: true` to customize the behavior when `autoLogin` is in place. See the xref:getting-started.adoc#_configure_security_and_login_parameters_optional[init() function documentation] for a full description of the available customizations.
 
 === REST API requests
-Because cookie-based authentication has a ThoughtSpot session cookie in the browser, REST API requests for the user can be made simply by including credentials in the REST API request.
+The Visual Embed SDK provides a link:https://developers.thoughtspot.com/docs/Function_tokenizedFetch[tokenizedFetch, target=_blank] function to use in place of the standard browser `fetch()` function, which will provide the current bearer token when using cookieless trusted authentication.
 
-With cookieless authentication, you will need to add the token as the bearer token in any REST API request you make to ThoughtSpot. This means you'll want to store the returned token in the global scope as part of the callback function you define for `getAuthToken`.
+Please see the documentation on xref:rest-apiv2-js.adoc[REST API V2.0 within a browser] for further explanation and example code.
 
 === Multiple user sessions in one browser
 Cookieless authentication is also useful for scenarios where the embedding application allows for being logged into multiple user accounts in different tabs, or quick switches between users. Cookie-based authentication restricts the whole browser to a single logged-in user per ThoughtSpot instance, while cookie-less allows each tab to use a different token without conflicts.


### PR DESCRIPTION
Ashish showed us the new-ish tokenizedFetch method in the SDK which makes all REST API calls simple when using cookieless trusted authentication. This updates the two pages that mentioned there being any difference in how to make the calls to link to this function along with update working example.