### PR TITLE
Update embed-without-sdk.adoc

### DIFF
--- a/modules/ROOT/pages/embed-without-sdk.adoc
+++ b/modules/ROOT/pages/embed-without-sdk.adoc
@@ -134,11 +134,11 @@ If you are using the new experience, click the Application switcher image:./imag
 
 Note the URL format to embed ThoughtSpot Search in an iFrame:
 
-`\https://{ThoughtSpot-Host}/?embedApp=true&dataSources=["cd252e5c-b552-49a8-821d-3eadaa049cca"]#/embed/answer`
+`\https://{ThoughtSpot-Host}/?embedApp=true&dataSources=["cd252e5c-b552-49a8-821d-3eadaa049cca"]#/answer`
 
 If you want to pre-define the search criteria, you can specify the search token string and `executeSearch` flag in the URL as shown in this example:
 
-`\https://{ThoughtSpot-Host}/?embedApp=true&dataSources=["cd252e5c-b552-49a8-821d-3eadaa049cca"]&searchTokenString=[sales][region]&executeSearch=true&isSearchEmbed=true#/embed/answer`
+`\https://{ThoughtSpot-Host}/?embedApp=true&dataSources=["cd252e5c-b552-49a8-821d-3eadaa049cca"]&searchTokenString=[sales][region]&executeSearch=true&isSearchEmbed=true#/answer`
 
 
 You can also add xref:embed-without-sdk.adoc#_additional_flags_to_customize_the_embedded_view[additional flags], xref:embed-without-sdk.adoc#rtOverridesIframe[runtime filters, and Parameter overrides] as query parameters in the embed URL.


### PR DESCRIPTION
The syntax for Search Embed without SDK was incorrect and caused redirect back to the Main page. Removed the incorrect "/embed/" portion and have tested these new formats are working.

Needs immediate push to main as this is incorrect in the docs out to customer (customer discovered the issue)