### PR TITLE
Update nav.adoc - added back Optimize section

### DIFF
--- a/modules/ROOT/pages/common/nav.adoc
+++ b/modules/ROOT/pages/common/nav.adoc
@@ -105,6 +105,11 @@ include::generated/typedoc/CustomSideNav.adoc[]
 **** link:{{navprefix}}/abac-user-parameters[ABAC via tokens]
 **** link:{{navprefix}}/rls-rules[RLS Rules]
 
+** link:{{navprefix}}/best-practices[Optimize app performance]
+*** link:{{navprefix}}/best-practices[Best practices]
+*** link:{{navprefix}}/prefetch[Prefetch static resources]
+*** link:{{navprefix}}/prerender[Prerender components]
+
 ** Other embedding methods
 *** link:{{navprefix}}/embed-without-sdk[Embed without SDK]
 *** link:{{navprefix}}/custom-viz-rest-api[Create a custom visualization]


### PR DESCRIPTION
Somehow the Optimize app performance section was removed in one of the other updates. Adding back from a previous version of the menu