### PR TITLE
link fixes

### DIFF
--- a/modules/ROOT/pages/configure-saml.adoc
+++ b/modules/ROOT/pages/configure-saml.adoc
@@ -11,7 +11,7 @@ ThoughtSpot supports the Single Sign-On (SSO) authentication method with the Sec
 == About SAML authentication
 
 SAML is an XML standard that allows secure exchange of user authentication and authorization data between trusted partners. It enables the following entities to exchange identity, authentication, and authorization information,
-For detailed information on SAML identities, see the following page link:https://docs.thoughtspot.com/cloud/9.10.0.cl/authentication-integration#_saml_entities["SAML entities" option, window=_blank].
+For detailed information on SAML identities, see link:https://docs.thoughtspot.com/cloud/latest/authentication-integration#_saml_entities[SAML entities, window=_blank].
 
 
 ////
@@ -35,8 +35,8 @@ A user whose identity information is managed by the IdP. The federated users hav
 
 //=== SAML assertion and attributes
 
-Both SP-initiated and IdP-initiated authentication workflows rely on assertions that are exchanged between the SAML endpoints through a web browser. For detailed information on these, see the following page
-link:https://docs.thoughtspot.com/cloud/9.10.0.cl/authentication-integration#saml-assertion["SAML assertion and attributes" option, window=_blank].
+Both SP-initiated and IdP-initiated authentication workflows rely on assertions that are exchanged between the SAML endpoints through a web browser. For detailed information on these, see
+link:https://docs.thoughtspot.com/cloud/latest/authentication-integration#saml-assertion[SAML assertion and attributes, window=_blank].
 
 
 ////
@@ -144,7 +144,7 @@ This is the port of the server where your ThoughtSpot instance is running.
 
 Unique Service Name::
 The unique key used by your Identity Provider to identify the client.
-For example, urn:thoughtspot:callosum:saml, or https://ssoappname.microsoft.com/ab12c3de4.
+For example, `urn:thoughtspot:callosum:saml` or `\https://ssoappname.microsoft.com/ab12c3de4`.
 
 Skew Time in Seconds::
 The allowed skew time, after which the authentication response is rejected and sent back from the IDP. 86400 is a popular choice.
@@ -158,9 +158,8 @@ Use https.
 IDP Metadata XML File::
 The absolute path to your Identity Provider’s metadata file. This file is provided by your IDP. For example, idp-meta.xml.
 
-
 For detailed information on enabling SAML
-authentication on your ThoughtSpot instance with IAMv1, see this page link:https://docs.thoughtspot.com/cloud/9.10.0.cl/authentication-integration[Enable SAML authentication]
+authentication on your ThoughtSpot instance with IAMv1, see this page link:https://docs.thoughtspot.com/cloud/latest/authentication-integration[Enable SAML authentication, window=_blank].
 
 
 ////
@@ -212,7 +211,7 @@ You need admin privileges to enable SAML authentication with IAMv2 on ThoughtSpo
 With link:https://docs.thoughtspot.com/cloud/latest/okta-iam["IAMv2", window=_blank], ThoughtSpot powers its internal authentication with Okta.
 IAMv2 involves several external improvements to authentication, including security enhancements.
 
-To link:https://docs.thoughtspot.com/cloud/9.10.0.cl/saml-okta#_enable_saml_authentication[enable SAML authentication using IAMv2, window_=blank], the *SAML2 IDP* tile needs to be selected from the IdP options in the *Admin* panel.
+To link:https://docs.thoughtspot.com/cloud/latest/saml-okta#_enable_saml_authentication[enable SAML authentication using IAMv2, window_=blank], the *SAML2 IDP* tile needs to be selected from the IdP options in the *Admin* panel.
 The following IdP details are to be provided:
 
 Connection name::
@@ -256,13 +255,11 @@ roles:: _Optional._
 Roles associated with the user. This mapping is crucial for assigning the correct roles and permissions to users based on their authentication through SAML.
 
 
-For detailed information on enabling SAML authentication on ThoughtSpot using IAMv2, and attributes, see this page
-link:https://docs.thoughtspot.com/cloud/9.10.0.cl/saml-okta#_enable_saml_authentication["Enable SAML authentication" option, window=_blank].
-
+For detailed information on enabling SAML authentication on ThoughtSpot using IAMv2, and attributes, see
+link:https://docs.thoughtspot.com/cloud/latest/saml-okta#_enable_saml_authentication[Enable SAML authentication, window=_blank].
 
 You can map your SAML groups,or groups and Orgs from your IdP to your ThoughtSpot. This means that you do not have to manually recreate your groups and Orgs in ThoughtSpot if they are already present in your IdP.
-Refer to link:https://docs.thoughtspot.com/cloud/9.10.0.cl/saml-group-mapping["Configure SAML group mapping" option, window=_blank].
-
+Refer to link:https://docs.thoughtspot.com/cloud/latest/saml-group-mapping[Configure SAML group mapping, window=_blank].
 
 
 [#idp-config]


### PR DESCRIPTION
merging link fixes for oidc and saml articles. It had incorrect links to main docs, and hence were broken.