### PR TITLE
Adjust tutorial pageids to not conflict with SDK references 

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -43,7 +43,7 @@ exports.createPages = async function ({ actions, graphql }) {
         const pageId = e.node.pageAttributes.pageid;
         if (sourceName === 'tutorials'){
            const relPathSplit = relPath.split('/');
-           const pageIdSplit = pageId.split('_');
+           const pageIdSplit = pageId.split('__');
            let finalPageId = pageId;
            if( pageIdSplit.length > 1) {
                 finalPageId = pageIdSplit[1];
@@ -70,7 +70,7 @@ exports.createPages = async function ({ actions, graphql }) {
         if (sourceName === 'tutorials'){            
            // One-level of subdirectory part of stub
            const relPathSplit = relPath.split('/');
-           const pageIdSplit = pageId.split('_');
+           const pageIdSplit = pageId.split('__');
            let finalPageId = pageId;
            if( pageIdSplit.length > 1) {
                 finalPageId = pageIdSplit[1];

--- a/modules/tutorials/pages/rest-api/rest-api-intro.adoc
+++ b/modules/tutorials/pages/rest-api/rest-api-intro.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title: ThoughtSpot REST API tutorials
-:page-pageid: rest-api_intro
+:page-pageid: rest-api__intro
 :page-description: This lesson covers the security setup necessary to embed ThoughtSpot into TSE applications.
 
 This tutorial is a hands-on guide to practically working with the ThoughtSpot V2.0 REST API.

--- a/modules/tutorials/pages/rest-api/rest-api_lesson-01.adoc
+++ b/modules/tutorials/pages/rest-api/rest-api_lesson-01.adoc
@@ -2,7 +2,7 @@
 :toc: true
 :toclevels: 3
 
-:page-pageid: rest-api_lesson-01
+:page-pageid: rest-api__lesson-01
 :description: Introduction to REST APIs and how ThoughtSpot defines the V2.0 REST API
 
 Before you begin this lesson, check if you have done all initial activities described in the xref:rest-api-intro.adoc[tutorial introduction].

--- a/modules/tutorials/pages/rest-api/rest-api_lesson-02.adoc
+++ b/modules/tutorials/pages/rest-api/rest-api_lesson-02.adoc
@@ -2,7 +2,7 @@
 :toc: true
 :toclevels: 3
 
-:page-pageid: rest-api_lesson-02
+:page-pageid: rest-api__lesson-02
 :description: A lesson on a simple implementation of the V2.0 using Python
 
 

--- a/modules/tutorials/pages/rest-api/rest-api_lesson-03.adoc
+++ b/modules/tutorials/pages/rest-api/rest-api_lesson-03.adoc
@@ -1,5 +1,5 @@
 = Complex REST API workflows
-:page-pageid: rest-api_lesson-03
+:page-pageid: rest-api__lesson-03
 :description: Complex REST API Workflows
 :toc: true
 :toclevels: 1

--- a/modules/tutorials/pages/rest-api/rest-api_lesson-04.adoc
+++ b/modules/tutorials/pages/rest-api/rest-api_lesson-04.adoc
@@ -2,7 +2,7 @@
 :toc: true
 :toclevels: 1
 
-:page-pageid: rest-api_lesson-04
+:page-pageid: rest-api__lesson-04
 :description: Browser JavaScript REST API implementation
 
 

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-intro.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-intro.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title: ThoughtSpot Embeddig fundamentals
-:page-pageid: tse-fundamentals_intro
+:page-pageid: tse-fundamentals__intro
 :page-description: This is a self-guided course on ThoughtSpot Embedding Fundamentals.
 
 

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-01.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-01.adoc
@@ -4,7 +4,7 @@
 :icons: font
 
 :page-title: Introduction to ThoughtSpot Embedded
-:page-pageid: tse-fundamentals_lesson-01
+:page-pageid: tse-fundamentals__lesson-01
 :page-description: Learn what is ThoughtSpot Embedded and fundamentals of embedding ThoughtSpot
 
 In this lesson, you'll learn the following:

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-02.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-02.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title: Set up for the course
-:page-pageid: tse-fundamentals_lesson-02
+:page-pageid: tse-fundamentals__lesson-02
 :page-description: Learn how to set up for the course, including prerequisites, documentation resources, Developer's Playground, and downloading starter code.
 
 In this lesson, we'll go through the requirements to get set up for the course. By the end, you'll  have the setup, tools, and resources required to complete the embedding steps in this course.

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-03.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-03.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title: Security setup
-:page-pageid:  tse-fundamentals_lesson-03
+:page-pageid:  tse-fundamentals__lesson-03
 :page-description: This lesson covers the security setup necessary to embed ThoughtSpot into TSE applications.
 
 ThoughtSpot Embedded applications operate securely with ThoughtSpot. This lesson will walk you through the security setup required for embedding ThoughtSpot.

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-04.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-04.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title: Start coding
-:page-pageid: tse-fundamentals_lesson-04
+:page-pageid: tse-fundamentals__lesson-04
 :page-description: This lesson guides you through reviewing and modifying the code, starting the web server, and testing the initial setup in a browser.
 
 Now that we've got everything set up, it's time to start coding.

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-05.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-05.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title: Init and Search embedding
-:page-pageid: tse-fundamentals_lesson-05
+:page-pageid: tse-fundamentals__lesson-05
 :page-description: This lesson covers initializing the SDK and embedding a ThoughtSpot search page using the developer's playground to generate the required code.
 
 At this point, we are ready to start embedding ThoughtSpot content.

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-06.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-06.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title: Lesson 6 - Embed Natural Language Search
-:page-pageid: tse-fundamentals_lesson-06
+:page-pageid: tse-fundamentals__lesson-06
 :page-description: This lesson demonstrates embedding a Natural Language Search component into the application using the same pattern as earlier lessons.
 
 Now that you've embedded a search, you'll notice that the rest of the embedding follows the same basic pattern:

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-07.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-07.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title: Embed a Liveboard
-:page-pageid: tse-fundamentals_lesson-07
+:page-pageid: tse-fundamentals__lesson-07
 :page-description: In this lesson we'll embed a full Liveboard using the `LiveboardEmbed` component.
 
 == Pre-conditions

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-08.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-08.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title:  Embed a Liveboard Visualization
-:page-pageid: tse-fundamentals_lesson-08
+:page-pageid: tse-fundamentals__lesson-08
 :page-description: In this lesson we'll embed a single visualization from a Liveboard using the `LiveboardEmbed` component.
 
 == Pre-conditions

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-09.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-09.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title: Embed the Full ThoughtSpot Application
-:page-pageid: tse-fundamentals_lesson-09
+:page-pageid: tse-fundamentals__lesson-09
 :page-description: In this lesson we'll embed the ThoughtSpot application using the `AppEmbed` component.
 
 == Pre-conditions

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-10.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-10.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title: Styling Embedded ThoughtSpot Content
-:page-pageid: tse-fundamentals_lesson-10
+:page-pageid: tse-fundamentals__lesson-10
 :page-description: In this lesson, we'll explore how to style embedded ThoughtSpot content using the UI and custom CSS.
 
 == Pre-conditions

--- a/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-11.adoc
+++ b/modules/tutorials/pages/tse-fundamentals/tse-fundamentals-lesson-11.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 :page-title: Course Summary
-:page-pageid: tse-fundamentals_lesson-11
+:page-pageid: tse-fundamentals__lesson-11
 :page-description: A summary of the ThoughtSpot Embedded course, additional resources, and next steps.
 
 In this course, we covered a lot of topics related to embedding ThoughtSpot into your own applications to give the analytics power to the end users.

--- a/src/components/LeftSidebar/helper.tsx
+++ b/src/components/LeftSidebar/helper.tsx
@@ -89,7 +89,7 @@ const isLinkMatching = (
     if (!href || !curLocation) return false;
 
     // Tutorials module pages have pageids like {subdirectory}_{real_url_ending}, must be split to generate matching URL
-    const pageIdSplit = pageid.split('_');
+    const pageIdSplit = pageid.split('__');
     if (pageIdSplit.length > 1){
          return (
             href.includes(`pageid=${pageid}`) ||


### PR DESCRIPTION
testing a fix to the page IDs of tutorial pages to allow the Reference pages to work in the menu system as well as tutorials (using double underscore in the tutorial page IDs)