### PR TITLE
SCAL-237361 : fixed tutorial links

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,6 +3,7 @@ const {
     DOC_NAV_PAGE_ID,
     NOT_FOUND_PAGE_ID,
 } = require('./src/configs/doc-configs');
+const { getDocLinkFromEdge } = require('./src/utils/gatsby-utils.js');
 
 exports.onPostBuild = () => {
     fsExtra.copyFileSync(
@@ -30,7 +31,6 @@ exports.createPages = async function ({ actions, graphql }) {
                                 relativePath
                             }
                         }
-                        
                     }
                 }
             }
@@ -39,24 +39,24 @@ exports.createPages = async function ({ actions, graphql }) {
 
     const namePageIdMap = {};
     data.allAsciidoc.edges.forEach((e) => {
-        const { sourceInstanceName: sourceName, relativePath : relPath } = e.node.parent;
+        const {
+            sourceInstanceName: sourceName,
+            relativePath: relPath,
+        } = e.node.parent;
         const pageId = e.node.pageAttributes.pageid;
-        if (sourceName === 'tutorials'){
-           const relPathSplit = relPath.split('/');
-           const pageIdSplit = pageId.split('__');
-           let finalPageId = pageId;
-           if( pageIdSplit.length > 1) {
+        if (sourceName === 'tutorials') {
+            const relPathSplit = relPath.split('/');
+            const pageIdSplit = pageId.split('__');
+            let finalPageId = pageId;
+            if (pageIdSplit.length > 1) {
                 finalPageId = pageIdSplit[1];
-           }
-           let mapPageId = `tutorials/` + finalPageId;
-           if(relPathSplit.length > 1) {
-                mapPageId = `tutorials/${relPathSplit[0]}/` + finalPageId;
-           }
-           namePageIdMap[e.node.parent.name] =
-                   mapPageId || NOT_FOUND_PAGE_ID;
-        }
-
-        else {
+            }
+            let mapPageId = `tutorials/${finalPageId}`;
+            if (relPathSplit.length > 1) {
+                mapPageId = `tutorials/${relPathSplit[0]}/${finalPageId}`;
+            }
+            namePageIdMap[e.node.parent.name] = mapPageId || NOT_FOUND_PAGE_ID;
+        } else {
             namePageIdMap[e.node.parent.name] =
                 e.node.pageAttributes.pageid || NOT_FOUND_PAGE_ID;
         }
@@ -64,41 +64,15 @@ exports.createPages = async function ({ actions, graphql }) {
 
     data.allAsciidoc.edges.forEach((edge) => {
         const { pageid: pageId } = edge.node.pageAttributes;
-        const { sourceInstanceName: sourceName, relativePath : relPath } = edge.node.parent;
 
-        // Tutorials module pageids follow pattern {subdirectory}_{final_url_stub} to give unique IDs in system but allow directory structure in URL
-        if (sourceName === 'tutorials'){            
-           // One-level of subdirectory part of stub
-           const relPathSplit = relPath.split('/');
-           const pageIdSplit = pageId.split('__');
-           let finalPageId = pageId;
-           if( pageIdSplit.length > 1) {
-                finalPageId = pageIdSplit[1];
-           }
-
-           let finalPath = `/tutorials/${finalPageId}`;
-           if(relPathSplit.length > 1) {
-               finalPath = `/tutorials/${relPathSplit[0]}/${finalPageId}`;
-           }
-           
-           actions.createPage({
-                    path: finalPath,
-                    component: require.resolve(
-                        './src/components/DevDocTemplate/index.tsx',
-                    ),
-                    context: { pageId, navId: DOC_NAV_PAGE_ID, namePageIdMap },
-                });
-        }
-
-        else {
-            actions.createPage({
-                path: `/${pageId}`,
-                component: require.resolve(
-                    './src/components/DevDocTemplate/index.tsx',
-                ),
-                context: { pageId, navId: DOC_NAV_PAGE_ID, namePageIdMap },
-            });
-        }
+        const docPath = getDocLinkFromEdge(edge);
+        actions.createPage({
+            path: docPath,
+            component: require.resolve(
+                './src/components/DevDocTemplate/index.tsx',
+            ),
+            context: { pageId, navId: DOC_NAV_PAGE_ID, namePageIdMap },
+        });
 
         if (pageId === 'introduction') {
             actions.createPage({

--- a/src/utils/aloglia.test.ts
+++ b/src/utils/aloglia.test.ts
@@ -53,6 +53,11 @@ const htmlForPreambleEle = `
 const divForpreamble = new JSDOM(htmlForPreambleEle).window.document;
 const dummyPreambleEle = divForpreamble.querySelector('#preamble');
 
+const parentNode = {
+    name: 'testname',
+    sourceInstanceName: 'testsource',
+    relativePath: 'testpath',
+};
 const asciiNode = {
     id: 'fa556896-4e38-5e7a-ab35-a45ee93d58ee',
     pageAttributes: {
@@ -61,6 +66,7 @@ const asciiNode = {
     document: {
         title: 'About REST APIs',
     },
+    parent: parentNode,
 };
 
 const asciiAlgoliaObj = {
@@ -114,7 +120,7 @@ describe('test cases from algolia search', () => {
             algoliaSearch.pageToAlgoliaRecordForASCII(
                 dummySectionEle,
                 'section',
-                asciiNode,
+                { node: asciiNode },
             ),
         ).toStrictEqual([asciiAlgoliaObj]);
     });
@@ -124,7 +130,7 @@ describe('test cases from algolia search', () => {
             algoliaSearch.pageToAlgoliaRecordForASCII(
                 dummyPreambleEle,
                 'preamble',
-                asciiNode,
+                { node: asciiNode },
             ),
         ).toStrictEqual([asciiPremableAlgoliaObj]);
     });

--- a/src/utils/gatsby-utils.js
+++ b/src/utils/gatsby-utils.js
@@ -1,0 +1,35 @@
+const getTutorialLinkFromEdge = (edge) => {
+    // Tutorials module pageids follow pattern {subdirectory}_{final_url_stub}
+    // to give unique IDs in system but allow directory structure in URL
+    const { pageid: pageId } = edge.node.pageAttributes;
+    const { relativePath: relPath } = edge.node.parent;
+    // One-level of subdirectory part of stub
+    const relPathSplit = relPath.split('/');
+    const pageIdSplit = pageId.split('__');
+    let finalPageId = pageId;
+    if (pageIdSplit.length > 1) {
+        finalPageId = pageIdSplit[1];
+    }
+
+    let finalPath = `/tutorials/${finalPageId}`;
+    if (relPathSplit.length > 1) {
+        finalPath = `/tutorials/${relPathSplit[0]}/${finalPageId}`;
+    }
+
+    return finalPath;
+};
+
+const getDocLinkFromEdge = (edge) => {
+    const { pageid: pageId } = edge.node.pageAttributes;
+    const { sourceInstanceName: sourceName } = edge.node.parent;
+
+    if (sourceName === 'tutorials') {
+        return getTutorialLinkFromEdge(edge);
+    }
+
+    return `/${pageId}`;
+};
+
+module.exports = {
+    getDocLinkFromEdge,
+};


### PR DESCRIPTION
# **PR Description**

## **Summary**
This PR updates the Algolia indexing process in our Gatsby site to include the `relativePath` for the new tutorial links. The `relativePath` is required for building accurate links in the Algolia index.

## **Changes Made**
1. **Updated GraphQL Query**:  
   - Enhanced the GraphQL query used in the Algolia plugin to fetch `relativePath` as part of the node data.  
   - Ensures the transformer function has all the necessary information to process tutorial links.

2. **Transformer Function Update**:  
   - Updated the transformer function in the Algolia plugin to use the same logic for generating links as used in page creation and internal links (referenced from the `gatsby-config.js` file).

3. **Dry Run for Testing**:  
   - Enabled the `dryRun` option in the `gatsby-plugin-algolia` configuration to test changes without polluting the live Algolia index.

## **Testing**
- Verified that the updated GraphQL query fetches the required `relativePath`.
- Confirmed that the transformer function generates the correct link structure.
- Performed a dry run of the indexing process to validate the changes without affecting the live Algolia index.

## **Notes**
- Check the `gatsby-config.js` file for reference logic used in link generation.
- Ensure proper testing on staging before removing the `dryRun` flag for production.
