### PR TITLE
SCAL-330848 Replace record_size = -1 guidance with pagination warning

### DIFF
--- a/modules/ROOT/pages/abac_rls-variables.adoc
+++ b/modules/ROOT/pages/abac_rls-variables.adoc
@@ -413,7 +413,7 @@ Set the `response_content` parameter to `METADATA_AND_VALUES` to see the values 
 ----
 {
   "record_offset": 0,
-  "record_size": -1,
+  "record_size": 50,
   "response_content": "METADATA_AND_VALUES"
 }
 ----

--- a/modules/ROOT/pages/collections.adoc
+++ b/modules/ROOT/pages/collections.adoc
@@ -97,7 +97,7 @@ In your `POST` request body, include the following parameters:
 
 |`name_pattern` a|__String__. Optional. Specify any case agnostic pattern to match the name of a Collection. Use `%` to perform a wildcard search by name.
 |`record_offset` a|__Number__. Optional. The index of the first record to be included. Default value is 0.
-|`record_size` a|__Number__. Optional. The total number of records to be searched. Default value is 10. Set to -1 to search across all available collections.
+|`record_size` a|__Number__. Optional. The total number of records to be searched. Default value is 10. Do not set this to `-1`; specify an explicit `record_size` and iterate through pages programmatically.
 |`collection_identifiers` a|__Array__. Optional. GUID of the Collection(s) to be searched. `name_pattern` takes precedence over the `collection_identifiers`.
 |`created_by_user_identifiers` a|__Array__. Optional. Searches for Collections by the name of the author.
 |`include_metadata` a|__Boolean__. Optional. When set to `true`, includes the metadata objects within each Collection in the response.

--- a/modules/ROOT/pages/data-report-v2-api.adoc
+++ b/modules/ROOT/pages/data-report-v2-api.adoc
@@ -580,7 +580,12 @@ When you make REST API calls to some v2 Data endpoints to query data, the API ma
 }
 ----
 
-You can set `record_size` to `-1` and `record_offset` to `0` for precise and complete results. The APIs return a maximum of 100000 rows of data at any given time. If you must retrieve a higher number of rows in an API call, contact ThoughtSpot Customer Support to increase the row size limit. However, if the record size and number of rows are high, the API may take a while to fetch the data, and the request may time out.
+[WARNING]
+====
+Do not set `record_size` to `-1`. On ThoughtSpot instances with a large number of objects or users, this can lead to slow responses, excessive logging, and out-of-memory failures. Specify an explicit `record_size` and iterate through pages programmatically.
+====
+
+The APIs return a maximum of 100000 rows of data at any given time. If you must retrieve a higher number of rows in an API call, contact ThoughtSpot Customer Support to increase the row size limit. However, if the record size and number of rows are high, the API may take a while to fetch the data, and the request may time out.
 
 == Runtime overrides
 The Data API endpoints support the following runtime overrides:

--- a/modules/ROOT/pages/deploy-with-tml-apis.adoc
+++ b/modules/ROOT/pages/deploy-with-tml-apis.adoc
@@ -145,7 +145,7 @@ The `/metadata/search` REST API endpoint has parameters to filter on `tag_identi
     "field_name": order_field,
     "order": "DESC"
   },
-    "record_size" : -1,
+    "record_size" : 50,
     "record_offset": 0
 }
 ----

--- a/modules/ROOT/pages/rest-api-v2-groups-search.adoc
+++ b/modules/ROOT/pages/rest-api-v2-groups-search.adoc
@@ -24,7 +24,10 @@ Throughout this article, requests and responses will be shown as JSON, without a
 }
 ----
 
-For precise results, you can set `record_size` to `-1` and `record_offset` to `0`.
+[WARNING]
+====
+Do not set `record_size` to `-1`. On ThoughtSpot instances with a large number of objects or users, this can lead to slow responses, excessive logging, and out-of-memory failures. Specify an explicit `record_size` and iterate through pages programmatically.
+====
 
 
 == Response format

--- a/modules/ROOT/pages/rest-api-v2-metadata-search.adoc
+++ b/modules/ROOT/pages/rest-api-v2-metadata-search.adoc
@@ -3889,7 +3889,10 @@ By default, the following pagination settings are applied to the API response re
 }
 ----
 
-If you are not using filtering options such as `tag_identifiers`, `type`, `created_by_user_identifiers`, `modified_by_user_identifiers`, `owned_by_user_identifiers`, `exclude_objects`, `include_auto_created_objects`, or `favorite_object_options`, set `record_size` to `-1` and `record_offset` to `0` for precise results.
+[WARNING]
+====
+Do not set `record_size` to `-1`. On ThoughtSpot instances with a large number of objects or users, this can lead to slow responses, excessive logging, and out-of-memory failures. Specify an explicit `record_size` and iterate through pages programmatically.
+====
 
 
 

--- a/modules/ROOT/pages/rest-api-v2-users-search.adoc
+++ b/modules/ROOT/pages/rest-api-v2-users-search.adoc
@@ -24,7 +24,10 @@ Throughout this article, requests and responses will be shown as JSON, without a
 }
 ----
 
-For precise results, you can set `record_size` to `-1` and `record_offset` to `0`.
+[WARNING]
+====
+Do not set `record_size` to `-1`. On ThoughtSpot instances with a large number of objects or users, this can lead to slow responses, excessive logging, and out-of-memory failures. Specify an explicit `record_size` and iterate through pages programmatically.
+====
 
 == Response format
 The response from any call to `users/search` will resemble the following:

--- a/modules/tutorials/pages/react-components/react-components_lesson-03.adoc
+++ b/modules/tutorials/pages/react-components/react-components_lesson-03.adoc
@@ -112,7 +112,8 @@ For endpoints that accept request parameters body, declare a `const` and set it 
 ----
 // Define the options for the metadata/search call
 const metadataOptions = {
-    record_size: -1,
+    record_offset: 0,
+    record_size: 50,
     include_headers: true,
     metadata: [
         {


### PR DESCRIPTION
Applies the docs team's revised copy so the public docs match the REST API Playground help text updated in SCAL-330570. Pages that recommended record_size = -1 now carry the approved warning; code samples that used -1 use a bounded page size instead.

SCAL-330848